### PR TITLE
Radiologics/imagemapper

### DIFF
--- a/examples/VTK4UpExample.js
+++ b/examples/VTK4UpExample.js
@@ -440,8 +440,6 @@ class VTK4UPExample extends Component {
       return <h4>Loading...</h4>;
     }
 
-    debugger;
-
     // Get labelmap rendering config
     const { configuration } = segmentationModule;
 
@@ -451,13 +449,15 @@ class VTK4UPExample extends Component {
           <div className="col-sm-4">
             <View2DImageMapper
               actors={[this.state.imageActors.I, this.state.labelmapActors.I]}
+              labelmapActors={[this.state.labelmapActors.I]}
               onCreated={this.storeApi(0, '2D')}
               orientation={'I'}
             />
           </div>
           <div className="col-sm-4">
             <View2DImageMapper
-              actors={[this.state.imageActors.J, this.state.labelmapActors.J]}
+              actors={[this.state.imageActors.J]}
+              labelmapActors={[this.state.labelmapActors.J]}
               onCreated={this.storeApi(1, '2D')}
               orientation={'J'}
             />
@@ -466,7 +466,8 @@ class VTK4UPExample extends Component {
         <div className="row">
           <div className="col-sm-4">
             <View2DImageMapper
-              actors={[this.state.imageActors.K, this.state.labelmapActors.K]}
+              actors={[this.state.imageActors.K]}
+              labelmapActors={[this.state.labelmapActors.K]}
               onCreated={this.storeApi(2, '2D')}
               orientation={'K'}
             />

--- a/examples/VTK4UpExample.js
+++ b/examples/VTK4UpExample.js
@@ -272,37 +272,20 @@ class VTK4UPExample extends Component {
       const windowWidth = Math.abs(range[1] - range[0]);
       const windowLevel = range[0] + windowWidth / 2;
 
-      // I
-      const imageMapperI = vtkImageMapper.newInstance();
-      const imageActorI = vtkImageSlice.newInstance();
+      const imageActors = [];
 
-      imageMapperI.setInputData(mrImageData);
-      imageActorI.setMapper(imageMapperI);
+      for (let i = 0; i < 3; i++) {
+        const imageMapper = vtkImageMapper.newInstance();
+        const imageActor = vtkImageSlice.newInstance();
 
-      imageActorI.getProperty().setColorWindow(windowWidth);
-      imageActorI.getProperty().setColorLevel(windowLevel);
+        imageMapper.setInputData(mrImageData);
+        imageActor.setMapper(imageMapper);
 
-      // J
-      const imageMapperJ = vtkImageMapper.newInstance();
-      const imageActorJ = vtkImageSlice.newInstance();
+        imageActor.getProperty().setColorWindow(windowWidth);
+        imageActor.getProperty().setColorLevel(windowLevel);
 
-      imageMapperJ.setInputData(mrImageData);
-      imageActorJ.setMapper(imageMapperJ);
-
-      imageActorJ.getProperty().setColorWindow(windowWidth);
-      imageActorJ.getProperty().setColorLevel(windowLevel);
-
-      // K
-      const imageMapperK = vtkImageMapper.newInstance();
-      const imageActorK = vtkImageSlice.newInstance();
-
-      imageMapperK.setInputData(mrImageData);
-      imageActorK.setMapper(imageMapperK);
-
-      imageActorK.getProperty().setColorWindow(windowWidth);
-      imageActorK.getProperty().setColorLevel(windowLevel);
-
-      ///////
+        imageActors.push(imageActor);
+      }
 
       // SEG
 
@@ -341,66 +324,66 @@ class VTK4UPExample extends Component {
       labelmapOFun.addPoint(0.5, 1);
       labelmapOFun.addPoint(1, 1);
 
-      // labelmapActorI
-
-      const labelmapMapperI = vtkImageMapper.newInstance();
-      const labelmapActorI = vtkImageSlice.newInstance();
+      const labelmapActors = [];
 
       outline.setInputData(labelmapDataObject);
       outline.setSlicingMode(2);
 
-      labelmapMapperI.setInputData(outline.getOutputData());
-      labelmapActorI.setMapper(labelmapMapperI);
-      labelmapActorI.getProperty().setInterpolationType(0);
+      for (let i = 0; i < 3; i++) {
+        const labelmapMapper = vtkImageMapper.newInstance();
+        const labelmapActor = vtkImageSlice.newInstance();
 
-      labelmapActorI
-        .getProperty()
-        .setRGBTransferFunction(labelmapTransferFunctions.cfun);
+        labelmapMapper.setInputData(outline.getOutputData());
+        labelmapActor.setMapper(labelmapMapper);
+        labelmapActor.getProperty().setInterpolationType(0);
 
-      labelmapActorI.getProperty().setScalarOpacity(labelmapOFun);
+        labelmapActor
+          .getProperty()
+          .setRGBTransferFunction(labelmapTransferFunctions.cfun);
 
-      // labelmapActorJ
+        labelmapActor.getProperty().setScalarOpacity(labelmapOFun);
 
-      const labelmapMapperJ = vtkImageMapper.newInstance();
-      const labelmapActorJ = vtkImageSlice.newInstance();
+        labelmapActors.push(labelmapActor);
+      }
 
-      outline.setInputData(labelmapDataObject);
-      outline.setSlicingMode(2);
+      const labelmapFillOFun = vtkPiecewiseFunction.newInstance();
 
-      labelmapMapperJ.setInputData(outline.getOutputData());
-      labelmapActorJ.setMapper(labelmapMapperJ);
-      labelmapActorJ.getProperty().setInterpolationType(0);
+      labelmapFillOFun.addPoint(0, 0); // our background value, 0, will be invisible
+      labelmapFillOFun.addPoint(0.5, 0.1);
+      labelmapFillOFun.addPoint(1, 0.2);
 
-      labelmapActorJ
-        .getProperty()
-        .setRGBTransferFunction(labelmapTransferFunctions.cfun);
+      const labelmapFillActors = [];
 
-      labelmapActorJ.getProperty().setScalarOpacity(labelmapOFun);
+      for (let i = 0; i < 3; i++) {
+        const labelmapFillMapper = vtkImageMapper.newInstance();
+        const labelmapFillActor = vtkImageSlice.newInstance();
 
-      // labelmapActorK
+        labelmapFillMapper.setInputData(labelmapDataObject);
+        labelmapFillActor.setMapper(labelmapFillMapper);
+        labelmapFillActor.getProperty().setInterpolationType(0);
 
-      const labelmapMapperK = vtkImageMapper.newInstance();
-      const labelmapActorK = vtkImageSlice.newInstance();
+        labelmapFillActor
+          .getProperty()
+          .setRGBTransferFunction(labelmapTransferFunctions.cfun);
 
-      outline.setInputData(labelmapDataObject);
-      outline.setSlicingMode(2);
+        labelmapFillActor.getProperty().setScalarOpacity(labelmapFillOFun);
 
-      labelmapMapperK.setInputData(outline.getOutputData());
-      labelmapActorK.setMapper(labelmapMapperK);
-      labelmapActorK.getProperty().setInterpolationType(0);
-
-      labelmapActorK
-        .getProperty()
-        .setRGBTransferFunction(labelmapTransferFunctions.cfun);
-
-      labelmapActorK.getProperty().setScalarOpacity(labelmapOFun);
+        labelmapFillActors.push(labelmapFillActor);
+      }
 
       this.setState({
-        imageActors: { I: imageActorI, J: imageActorI, K: imageActorK },
+        imageActors: {
+          I: imageActors[0],
+          J: imageActors[1],
+          K: imageActors[2],
+        },
         labelmapActors: {
-          I: labelmapActorI,
-          J: labelmapActorJ,
-          K: labelmapActorK,
+          I: labelmapActors[0],
+          IFill: labelmapFillActors[0],
+          J: labelmapActors[1],
+          JFill: labelmapFillActors[1],
+          K: labelmapActors[2],
+          KFill: labelmapFillActors[1],
         },
         volumeRenderingVolumes: [segVol],
         paintFilterLabelMapImageData: labelmapDataObject,
@@ -440,6 +423,8 @@ class VTK4UPExample extends Component {
       return <h4>Loading...</h4>;
     }
 
+    debugger;
+
     // Get labelmap rendering config
     const { configuration } = segmentationModule;
 
@@ -449,7 +434,10 @@ class VTK4UPExample extends Component {
           <div className="col-sm-4">
             <View2DImageMapper
               actors={[this.state.imageActors.I, this.state.labelmapActors.I]}
-              labelmapActors={[this.state.labelmapActors.I]}
+              labelmapActors={[
+                this.state.labelmapActors.IFill,
+                this.state.labelmapActors.I,
+              ]}
               onCreated={this.storeApi(0, '2D')}
               orientation={'I'}
             />
@@ -457,7 +445,10 @@ class VTK4UPExample extends Component {
           <div className="col-sm-4">
             <View2DImageMapper
               actors={[this.state.imageActors.J]}
-              labelmapActors={[this.state.labelmapActors.J]}
+              labelmapActors={[
+                this.state.labelmapActors.JFill,
+                this.state.labelmapActors.J,
+              ]}
               onCreated={this.storeApi(1, '2D')}
               orientation={'J'}
             />
@@ -467,7 +458,10 @@ class VTK4UPExample extends Component {
           <div className="col-sm-4">
             <View2DImageMapper
               actors={[this.state.imageActors.K]}
-              labelmapActors={[this.state.labelmapActors.K]}
+              labelmapActors={[
+                this.state.labelmapActors.KFill,
+                this.state.labelmapActors.K,
+              ]}
               onCreated={this.storeApi(2, '2D')}
               orientation={'K'}
             />
@@ -484,22 +478,5 @@ class VTK4UPExample extends Component {
     );
   }
 }
-
-/** // Old View2D props
-paintFilterLabelMapImageData={
-  this.state.paintFilterLabelMapImageData
-}
-paintFilterBackgroundImageData={
-  this.state.paintFilterBackgroundImageData
-}
-labelmapRenderingOptions={{
-  colorLUT: this.state.labelmapColorLUT,
-  globalOpacity: configuration.fillAlpha,
-  visible: configuration.renderFill,
-  outlineThickness: configuration.outlineWidth,
-  renderOutline: configuration.renderOutline,
-  segmentsDefaultProperties: [], // Its kinda dumb that this needs to be present.
-}}
-*/
 
 export default VTK4UPExample;

--- a/examples/VTK4UpExample.js
+++ b/examples/VTK4UpExample.js
@@ -423,11 +423,6 @@ class VTK4UPExample extends Component {
       return <h4>Loading...</h4>;
     }
 
-    debugger;
-
-    // Get labelmap rendering config
-    const { configuration } = segmentationModule;
-
     return (
       <>
         <div className="row">

--- a/src/VTKViewport/View2D.js
+++ b/src/VTKViewport/View2D.js
@@ -41,7 +41,7 @@ export default class View2D extends Component {
       visible: true,
       renderOutline: true,
       segmentsDefaultProperties: [],
-      onNewSegmentationRequested: () => { }
+      onNewSegmentationRequested: () => {},
     },
   };
 
@@ -61,7 +61,7 @@ export default class View2D extends Component {
     };
     this.interactorStyleSubs = [];
     this.state = {
-      voi: this.getVOI(props.volumes[0])
+      voi: this.getVOI(props.volumes[0]),
     };
 
     this.apiProperties = {};
@@ -478,7 +478,7 @@ export default class View2D extends Component {
 
     if (
       prevProps.paintFilterLabelMapImageData !==
-      this.props.paintFilterLabelMapImageData &&
+        this.props.paintFilterLabelMapImageData &&
       this.props.paintFilterLabelMapImageData
     ) {
       this.subs.labelmap.unsubscribe();
@@ -510,12 +510,13 @@ export default class View2D extends Component {
 
       this.labelmap = labelmap;
 
-      this.props.labelmapRenderingOptions.segmentsDefaultProperties
-        .forEach((properties, segmentNumber) => {
+      this.props.labelmapRenderingOptions.segmentsDefaultProperties.forEach(
+        (properties, segmentNumber) => {
           if (properties) {
             this.setSegmentVisibility(segmentNumber, properties.visible);
           }
-        });
+        }
+      );
 
       // Add actors.
       if (this.labelmap && this.labelmap.actor) {
@@ -544,7 +545,7 @@ export default class View2D extends Component {
     if (
       prevProps.labelmapRenderingOptions &&
       prevProps.labelmapRenderingOptions.visible !==
-      this.props.labelmapRenderingOptions.visible
+        this.props.labelmapRenderingOptions.visible
     ) {
       this.labelmap.actor.setVisibility(
         prevProps.labelmapRenderingOptions.visible

--- a/src/VTKViewport/View2DImageMapper.js
+++ b/src/VTKViewport/View2DImageMapper.js
@@ -1,0 +1,375 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import vtkGenericRenderWindow from 'vtk.js/Sources/Rendering/Misc/GenericRenderWindow';
+import vtkWidgetManager from 'vtk.js/Sources/Widgets/Core/WidgetManager';
+import vtkInteractorStyleMPRSlice from './vtkInteractorStyleMPRSlice';
+import vtkSVGWidgetManager from './vtkSVGWidgetManager';
+import ViewportOverlay from '../ViewportOverlay/ViewportOverlay.js';
+import { createSub } from '../lib/createSub.js';
+import { uuidv4 } from './../helpers';
+import setGlobalOpacity from './setGlobalOpacity';
+
+export default class View2D extends Component {
+  static propTypes = {
+    volumes: PropTypes.array.isRequired,
+    actors: PropTypes.array,
+    dataDetails: PropTypes.object,
+    onCreated: PropTypes.func,
+    onDestroyed: PropTypes.func,
+    orientation: PropTypes.object,
+  };
+
+  static defaultProps = {};
+
+  constructor(props) {
+    super(props);
+
+    this.genericRenderWindow = null;
+    this.widgetManager = vtkWidgetManager.newInstance();
+    this.container = React.createRef();
+    this.subs = {
+      interactor: createSub(),
+      data: createSub(),
+      labelmap: createSub(),
+    };
+    this.interactorStyleSubs = [];
+    this.state = {
+      voi: this.getVOI(props.volumes[0]),
+    };
+
+    this.apiProperties = {};
+  }
+
+  componentDidMount() {
+    // Tracking ID to tie emitted events to this component
+    const uid = uuidv4();
+
+    this.genericRenderWindow = vtkGenericRenderWindow.newInstance({
+      background: [0, 0, 0],
+    });
+
+    this.genericRenderWindow.setContainer(this.container.current);
+
+    let widgets = [];
+    let filters = [];
+    let actors = [];
+    let volumes = [];
+
+    const radius = 5;
+    const label = 1;
+
+    this.renderer = this.genericRenderWindow.getRenderer();
+    this.renderWindow = this.genericRenderWindow.getRenderWindow();
+    const oglrw = this.genericRenderWindow.getOpenGLRenderWindow();
+
+    // update view node tree so that vtkOpenGLHardwareSelector can access
+    // the vtkOpenGLRenderer instance.
+    oglrw.buildPass(true);
+
+    const istyle = vtkInteractorStyleMPRSlice.newInstance();
+    this.renderWindow.getInteractor().setInteractorStyle(istyle);
+
+    // TODO unsubscribe from this before component unmounts.
+
+    this.widgetManager.disablePicking();
+
+    // trigger pipeline update
+    this.componentDidUpdate({});
+
+    if (this.labelmap && this.labelmap.actor) {
+      actors = actors.concat(this.labelmap.actor);
+    }
+
+    if (this.props.volumes) {
+      volumes = volumes.concat(this.props.volumes);
+    }
+
+    // Set orientation based on props
+    if (this.props.orientation) {
+      const { orientation } = this.props;
+
+      istyle.setSliceOrientation(orientation.sliceNormal, orientation.viewUp);
+    } else {
+      istyle.setSliceNormal(0, 0, 1);
+    }
+
+    const camera = this.renderer.getActiveCamera();
+
+    camera.setParallelProjection(true);
+    this.renderer.resetCamera();
+
+    istyle.setVolumeActor(this.props.volumes[0]);
+    const range = istyle.getSliceRange();
+    istyle.setSlice((range[0] + range[1]) / 2);
+
+    const svgWidgetManager = vtkSVGWidgetManager.newInstance();
+
+    svgWidgetManager.setRenderer(this.renderer);
+    svgWidgetManager.setScale(1);
+
+    this.svgWidgetManager = svgWidgetManager;
+
+    // TODO: Not sure why this is necessary to force the initial draw
+    this.genericRenderWindow.resize();
+
+    const boundUpdateVOI = this.updateVOI.bind(this);
+    const boundGetOrienation = this.getOrientation.bind(this);
+    const boundSetInteractorStyle = this.setInteractorStyle.bind(this);
+    const boundAddSVGWidget = this.addSVGWidget.bind(this);
+    const boundGetApiProperty = this.getApiProperty.bind(this);
+    const boundSetApiProperty = this.setApiProperty.bind(this);
+    const boundSetSegmentRGB = this.setSegmentRGB.bind(this);
+    const boundSetSegmentRGBA = this.setSegmentRGBA.bind(this);
+    const boundSetSegmentAlpha = this.setSegmentAlpha.bind(this);
+    const boundUpdateImage = this.updateImage.bind(this);
+    const boundSetSegmentVisibility = this.setSegmentVisibility.bind(this);
+    const boundSetGlobalOpacity = this.setGlobalOpacity.bind(this);
+    const boundSetVisibility = this.setVisibility.bind(this);
+    const boundSetOutlineThickness = this.setOutlineThickness.bind(this);
+    const boundOutlineRendering = this.setOutlineRendering.bind(this);
+    const boundRequestNewSegmentation = this.requestNewSegmentation.bind(this);
+
+    this.svgWidgets = {};
+
+    if (this.props.onCreated) {
+      /**
+       * Note: The contents of this Object are
+       * considered part of the API contract
+       * we make with consumers of this component.
+       */
+      const api = {
+        uid, // Tracking id available on `api`
+        genericRenderWindow: this.genericRenderWindow,
+        widgetManager: this.widgetManager,
+        svgWidgetManager: this.svgWidgetManager,
+        addSVGWidget: boundAddSVGWidget,
+        container: this.container.current,
+        widgets,
+        svgWidgets: this.svgWidgets,
+        filters,
+        actors,
+        volumes,
+        _component: this,
+        updateImage: boundUpdateImage,
+        updateVOI: boundUpdateVOI,
+        getOrientation: boundGetOrienation,
+        setInteractorStyle: boundSetInteractorStyle,
+        setSegmentRGB: boundSetSegmentRGB,
+        setSegmentRGBA: boundSetSegmentRGBA,
+        setSegmentAlpha: boundSetSegmentAlpha,
+        setSegmentVisibility: boundSetSegmentVisibility,
+        setGlobalOpacity: boundSetGlobalOpacity,
+        setVisibility: boundSetVisibility,
+        setOutlineThickness: boundSetOutlineThickness,
+        setOutlineRendering: boundOutlineRendering,
+        requestNewSegmentation: boundRequestNewSegmentation,
+        get: boundGetApiProperty,
+        set: boundSetApiProperty,
+        type: 'VIEW2D',
+      };
+
+      this.props.onCreated(api);
+    }
+  }
+
+  getApiProperty(propertyName) {
+    return this.apiProperties[propertyName];
+  }
+
+  setApiProperty(propertyName, value) {
+    this.apiProperties[propertyName] = value;
+  }
+
+  addSVGWidget(widget, name) {
+    const { svgWidgetManager } = this;
+
+    svgWidgetManager.addWidget(widget);
+    svgWidgetManager.render();
+
+    this.svgWidgets[name] = widget;
+  }
+
+  updateImage() {
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+
+    renderWindow.render();
+  }
+
+  setInteractorStyle({ istyle, callbacks = {}, configuration = {} }) {
+    const { volumes } = this.props;
+    const renderWindow = this.genericRenderWindow.getRenderWindow();
+    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+
+    // unsubscribe from previous iStyle's callbacks.
+    while (this.interactorStyleSubs.length) {
+      this.interactorStyleSubs.pop().unsubscribe();
+    }
+
+    let currentViewport;
+    if (currentIStyle.getViewport && istyle.getViewport) {
+      currentViewport = currentIStyle.getViewport();
+    }
+
+    const slabThickness = this.getSlabThickness();
+    const interactor = renderWindow.getInteractor();
+
+    interactor.setInteractorStyle(istyle);
+
+    // TODO: Not sure why this is required the second time this function is called
+    istyle.setInteractor(interactor);
+
+    if (currentViewport) {
+      istyle.setViewport(currentViewport);
+    }
+
+    if (istyle.getVolumeActor() !== volumes[0]) {
+      if (slabThickness && istyle.setSlabThickness) {
+        istyle.setSlabThickness(slabThickness);
+      }
+
+      istyle.setVolumeActor(volumes[0]);
+    }
+
+    // Add appropriate callbacks
+    Object.keys(callbacks).forEach(key => {
+      if (typeof istyle[key] === 'function') {
+        const subscription = istyle[key](callbacks[key]);
+
+        if (subscription && typeof subscription.unsubscribe === 'function') {
+          this.interactorStyleSubs.push(subscription);
+        }
+      }
+    });
+
+    // Set Configuration
+    if (configuration) {
+      istyle.set(configuration);
+    }
+
+    renderWindow.render();
+  }
+
+  updateVOI(windowWidth, windowCenter) {
+    this.setState({ voi: { windowWidth, windowCenter } });
+  }
+
+  getOrientation() {
+    return this.props.orientation;
+  }
+
+  setSegmentRGBA(segmentIndex, [red, green, blue, alpha]) {
+    this.setSegmentRGB(segmentIndex, [red, green, blue]);
+    this.setSegmentAlpha(segmentIndex, alpha);
+  }
+
+  setGlobalOpacity(globalOpacity) {
+    const { labelmap } = this;
+    const colorLUT = this.props.labelmapRenderingOptions.colorLUT;
+    setGlobalOpacity(labelmap, colorLUT, globalOpacity);
+  }
+
+  setVisibility(visible) {
+    const { labelmap } = this;
+    labelmap.actor.setVisibility(visible);
+  }
+
+  setOutlineThickness(outlineThickness) {
+    const { labelmap } = this;
+    labelmap.actor.getProperty().setLabelOutlineThickness(outlineThickness);
+  }
+
+  setOutlineRendering(renderOutline) {
+    const { labelmap } = this;
+    labelmap.actor.getProperty().setUseLabelOutline(renderOutline);
+  }
+
+  requestNewSegmentation() {
+    this.props.labelmapRenderingOptions.onNewSegmentationRequested();
+  }
+
+  setSegmentRGB(segmentIndex, [red, green, blue]) {
+    const { labelmap } = this;
+
+    labelmap.cfun.addRGBPoint(segmentIndex, red / 255, green / 255, blue / 255);
+  }
+
+  setSegmentVisibility(segmentIndex, isVisible) {
+    this.setSegmentAlpha(segmentIndex, isVisible ? 255 : 0);
+  }
+
+  setSegmentAlpha(segmentIndex, alpha) {
+    const { labelmap } = this;
+    let { globalOpacity } = this.props.labelmapRenderingOptions;
+
+    if (globalOpacity === undefined) {
+      globalOpacity = 1.0;
+    }
+
+    const segmentOpacity = (alpha / 255) * globalOpacity;
+
+    labelmap.ofun.addPointLong(segmentIndex, segmentOpacity, 0.5, 1.0);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.volumes !== this.props.volumes) {
+      this.props.volumes.forEach(volume => {
+        if (!volume.isA('vtkVolume')) {
+          console.warn('Data to <Vtk2D> is not vtkVolume data');
+        }
+      });
+
+      if (this.props.volumes.length) {
+        this.props.volumes.forEach(this.renderer.addVolume);
+      } else {
+        // TODO: Remove all volumes
+      }
+
+      this.renderWindow.render();
+    }
+  }
+
+  componentWillUnmount() {
+    Object.keys(this.subs).forEach(k => {
+      this.subs[k].unsubscribe();
+    });
+
+    if (this.props.onDestroyed) {
+      this.props.onDestroyed();
+    }
+
+    this.genericRenderWindow.delete();
+  }
+
+  getVOI = actor => {
+    // Note: This controls window/level
+
+    // TODO: Make this work reactively with onModified...
+
+    debugger;
+    const rgbTransferFunction = actor.getProperty().getRGBTransferFunction(0);
+    const range = rgbTransferFunction.getMappingRange();
+    const windowWidth = Math.abs(range[1] - range[0]);
+    const windowCenter = range[0] + windowWidth / 2;
+
+    return {
+      windowCenter,
+      windowWidth,
+    };
+  };
+
+  render() {
+    if (!this.props.volumes || !this.props.volumes.length) {
+      return null;
+    }
+
+    const style = { width: '100%', height: '100%', position: 'relative' };
+    const voi = this.state.voi;
+
+    return (
+      <div style={style}>
+        <div ref={this.container} style={style} />
+        <ViewportOverlay {...this.props.dataDetails} voi={voi} />
+      </div>
+    );
+  }
+}

--- a/src/VTKViewport/View2DImageMapper.js
+++ b/src/VTKViewport/View2DImageMapper.js
@@ -13,6 +13,7 @@ import { uuidv4 } from './../helpers';
 export default class View2DImageMapper extends Component {
   static propTypes = {
     actors: PropTypes.array,
+    labelmapActors: PropTypes.array,
     dataDetails: PropTypes.object,
     onCreated: PropTypes.func,
     onDestroyed: PropTypes.func,
@@ -163,7 +164,6 @@ export default class View2DImageMapper extends Component {
 
     // Update slices of labelmaps when source data slice changed
     imageMapper.onModified(() => {
-      debugger;
       labelmapActors.forEach(actor => {
         actor.getMapper().setSlice(imageMapper.getSlice());
       });
@@ -261,57 +261,46 @@ export default class View2DImageMapper extends Component {
   }
 
   setInteractorStyle({ istyle, callbacks = {}, configuration = {} }) {
-    const { volumes } = this.props;
-    const renderWindow = this.genericRenderWindow.getRenderWindow();
-    const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
-
-    // unsubscribe from previous iStyle's callbacks.
-    while (this.interactorStyleSubs.length) {
-      this.interactorStyleSubs.pop().unsubscribe();
-    }
-
-    let currentViewport;
-    if (currentIStyle.getViewport && istyle.getViewport) {
-      currentViewport = currentIStyle.getViewport();
-    }
-
-    const slabThickness = this.getSlabThickness();
-    const interactor = renderWindow.getInteractor();
-
-    interactor.setInteractorStyle(istyle);
-
-    // TODO: Not sure why this is required the second time this function is called
-    istyle.setInteractor(interactor);
-
-    if (currentViewport) {
-      istyle.setViewport(currentViewport);
-    }
-
-    if (istyle.getVolumeActor() !== volumes[0]) {
-      if (slabThickness && istyle.setSlabThickness) {
-        istyle.setSlabThickness(slabThickness);
-      }
-
-      istyle.setVolumeActor(volumes[0]);
-    }
-
-    // Add appropriate callbacks
-    Object.keys(callbacks).forEach(key => {
-      if (typeof istyle[key] === 'function') {
-        const subscription = istyle[key](callbacks[key]);
-
-        if (subscription && typeof subscription.unsubscribe === 'function') {
-          this.interactorStyleSubs.push(subscription);
-        }
-      }
-    });
-
-    // Set Configuration
-    if (configuration) {
-      istyle.set(configuration);
-    }
-
-    renderWindow.render();
+    // TODO -> we may have different interactor styles here.
+    // const { volumes } = this.props;
+    // const renderWindow = this.genericRenderWindow.getRenderWindow();
+    // const currentIStyle = renderWindow.getInteractor().getInteractorStyle();
+    // // unsubscribe from previous iStyle's callbacks.
+    // while (this.interactorStyleSubs.length) {
+    //   this.interactorStyleSubs.pop().unsubscribe();
+    // }
+    // let currentViewport;
+    // if (currentIStyle.getViewport && istyle.getViewport) {
+    //   currentViewport = currentIStyle.getViewport();
+    // }
+    // const slabThickness = this.getSlabThickness();
+    // const interactor = renderWindow.getInteractor();
+    // interactor.setInteractorStyle(istyle);
+    // // TODO: Not sure why this is required the second time this function is called
+    // istyle.setInteractor(interactor);
+    // if (currentViewport) {
+    //   istyle.setViewport(currentViewport);
+    // }
+    // if (istyle.getVolumeActor() !== volumes[0]) {
+    //   if (slabThickness && istyle.setSlabThickness) {
+    //     istyle.setSlabThickness(slabThickness);
+    //   }
+    //   istyle.setVolumeActor(volumes[0]);
+    // }
+    // // Add appropriate callbacks
+    // Object.keys(callbacks).forEach(key => {
+    //   if (typeof istyle[key] === 'function') {
+    //     const subscription = istyle[key](callbacks[key]);
+    //     if (subscription && typeof subscription.unsubscribe === 'function') {
+    //       this.interactorStyleSubs.push(subscription);
+    //     }
+    //   }
+    // });
+    // // Set Configuration
+    // if (configuration) {
+    //   istyle.set(configuration);
+    // }
+    // renderWindow.render();
   }
 
   updateVOI(windowWidth, windowCenter) {
@@ -320,24 +309,6 @@ export default class View2DImageMapper extends Component {
 
   getOrientation() {
     return this.props.orientation;
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.volumes !== this.props.volumes) {
-      this.props.volumes.forEach(volume => {
-        if (!volume.isA('vtkVolume')) {
-          console.warn('Data to <Vtk2D> is not vtkVolume data');
-        }
-      });
-
-      if (this.props.volumes.length) {
-        this.props.volumes.forEach(this.renderer.addVolume);
-      } else {
-        // TODO: Remove all volumes
-      }
-
-      this.renderWindow.render();
-    }
   }
 
   setCamera(sliceMode, renderer, data) {
@@ -365,7 +336,6 @@ export default class View2DImageMapper extends Component {
 
   getVOI = actor => {
     // Note: This controls window/level
-
     const windowCenter = actor.getProperty().getColorLevel();
     const windowWidth = actor.getProperty().getColorWindow();
 

--- a/src/VTKViewport/View2DImageMapper.js
+++ b/src/VTKViewport/View2DImageMapper.js
@@ -105,9 +105,6 @@ export default class View2DImageMapper extends Component {
     this.widgetManager.disablePicking();
     this.widgetManager.setRenderer(this.labelmapRenderer);
 
-    // trigger pipeline update
-    this.componentDidUpdate({});
-
     // Add all actors to renderer
     actors.forEach(actor => {
       renderer.addViewProp(actor);

--- a/src/VTKViewport/View2DImageMapper.js
+++ b/src/VTKViewport/View2DImageMapper.js
@@ -78,8 +78,6 @@ export default class View2DImageMapper extends Component {
       renderer.addViewProp(actor);
     });
 
-    // Use orientation prob to set slice direction
-
     let sliceMode;
 
     const imageActor = actors[0];
@@ -91,6 +89,7 @@ export default class View2DImageMapper extends Component {
 
     const { orientation } = this.props;
 
+    // Use orientation prob to set slice direction
     switch (orientation) {
       case 'I':
         sliceMode = vtkImageMapper.SlicingMode.I;
@@ -106,13 +105,21 @@ export default class View2DImageMapper extends Component {
         break;
     }
 
-    // TODO -> Deal with label volume
+    actors.forEach(actor => {
+      // Set slice orientation/mode and camera view
+      actor.getMapper().setSlicingMode(sliceMode);
 
-    // Default slice orientation/mode and camera view
-    imageMapper.setSlicingMode(sliceMode);
+      // Set middle slice.
+      actor.getMapper().setSlice(Math.floor(dimensionsOfSliceDirection / 2));
+    });
 
-    // Set middle slice.
-    imageMapper.setSlice(Math.floor(dimensionsOfSliceDirection / 2));
+    const secondaryActors = actors.slice(1);
+    // updateSlices when the object is made.
+    imageMapper.onModified(() => {
+      secondaryActors.forEach(actor => {
+        actor.getMapper().setSlice(imageMapper.getSlice());
+      });
+    });
 
     // Set up camera
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import View2D from './VTKViewport/View2D';
+import View2DImageMapper from './VTKViewport/View2DImageMapper';
 import View3D from './VTKViewport/View3D';
 import vtkInteractorStyleMPRSlice from './VTKViewport/vtkInteractorStyleMPRSlice.js';
 import vtkInteractorStyleMPRWindowLevel from './VTKViewport/vtkInteractorStyleMPRWindowLevel.js';
@@ -15,6 +16,7 @@ import EVENTS from './events.js';
 
 export {
   View2D,
+  View2DImageMapper,
   View3D,
   ViewportOverlay,
   ViewportData,

--- a/src/lib/getImageData.js
+++ b/src/lib/getImageData.js
@@ -67,6 +67,8 @@ export default function getImageData(imageIds, displaySetInstanceUid) {
   const imageData = vtkImageData.newInstance();
   const direction = [...rowCosineVec, ...colCosineVec, ...scanAxisNormal];
 
+  debugger;
+
   imageData.setDimensions(xVoxels, yVoxels, zVoxels);
   imageData.setSpacing(xSpacing, ySpacing, zSpacing);
   imageData.setDirection(direction);

--- a/src/lib/getImageData.js
+++ b/src/lib/getImageData.js
@@ -67,8 +67,6 @@ export default function getImageData(imageIds, displaySetInstanceUid) {
   const imageData = vtkImageData.newInstance();
   const direction = [...rowCosineVec, ...colCosineVec, ...scanAxisNormal];
 
-  debugger;
-
   imageData.setDimensions(xVoxels, yVoxels, zVoxels);
   imageData.setSpacing(xSpacing, ySpacing, zSpacing);
   imageData.setDirection(direction);


### PR DESCRIPTION
This PR adds a new component to do memory efficient 2D image rendering for source data + segmentations with source + outline.

There are no tools yet other than the default window level.

The labelmaps are moved to a render only layer, and this layer is set to track the primary layer. This way we only have to tell tools to manipulate the source data.

<img width="783" alt="Screenshot 2020-10-01 at 14 33 07" src="https://user-images.githubusercontent.com/25818497/94819982-d75e0280-03f7-11eb-8c3e-aeef405429cf.png">
